### PR TITLE
Update dependencies on Wercker box.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN sudo apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
-RUN npm install -g bower gulp gulp-imagemin
 # Install Bundler
 RUN gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN sudo apt-get update
 
+# Install ChromeDriver
+RUN sudo apt-get -y install libxpm4 libxrender1 libgtk2.0-0 libnss3 libgconf-2-4
+RUN sudo apt-get -y install chromium-browser
+
 # Install MongoDB 3.2
 RUN sudo apt-get -y install curl git libnotify-bin ruby software-properties-common build-essential
 RUN sudo LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 RUN sudo apt-get update
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+# Install Node 8.x LTS
+RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
 RUN npm install -g bower gulp gulp-imagemin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Morgan Rich
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN sudo apt-get update
+
+# Install MongoDB 3.2
 RUN sudo apt-get -y install curl git libnotify-bin ruby software-properties-common build-essential
 RUN sudo LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
 RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
@@ -15,15 +17,19 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
 RUN npm install -g bower gulp gulp-imagemin
+# Install Bundler
 RUN gem install bundler
 
+# Install PHP 7.0
 RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
 php7.0 mongodb-org php7.0-mongo php7.0-common php7.0-dev php7.0-fpm php7.0-cli \
 php7.0-bcmath php7.0-bz2 php7.0-dba php7.0-mcrypt  php7.0-gd php7.0-mysql php7.0-curl php7.0-json php7.0-readline php7.0-mbstring php7.0-mongodb php7.0-soap php7.0-xml php7.0-zip 
 
+# Install Composer
 RUN sudo curl -sS https://getcomposer.org/installer | php
 RUN sudo mv composer.phar /usr/local/bin/composer
 
+# Configure MySQL
 RUN { \
     echo mysql-community-server mysql-community-server/data-dir select ''; \
     echo mysql-community-server mysql-community-server/root-pass password ''; \


### PR DESCRIPTION
## Changes
This pull request updates dependencies on our Wercker box:

📜 Updates to Node 8.x, the new LTS release. This comes bundled with NPM 5.3, which gives us deterministic builds w/ lock files & improves build times pretty significantly (72s to 30s).

💻 Installs ChromeDriver, which we use for [Laravel Dusk](https://laravel.com/docs/5.5/dusk) tests in Rogue (otherwise we need to spend ~60s doing this for every build).

🙅‍♂️ Removes Bower & Gulp global installs. We don't use those on any applications, and could always install them case-by-case as a `wercker.yml` step if we did.

You can check out an example build using this Docker box in the Rogue repo.